### PR TITLE
Remove redundant scheme codes

### DIFF
--- a/changelog/db.changelog-1.3.xml
+++ b/changelog/db.changelog-1.3.xml
@@ -1,0 +1,9 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-3.9.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+  <changeSet author="John Watson" id="1">
+    <tagDatabase tag="v1.3.0" />
+  </changeSet>
+  <changeSet author="John Watson" id="2">
+    <delete tableName="schemeCodes" />
+  </changeSet>
+</databaseChangeLog>

--- a/changelog/db.changelog.xml
+++ b/changelog/db.changelog.xml
@@ -7,4 +7,5 @@
   <include  file="changelog/db.changelog-1.0.xml"/>
   <include  file="changelog/db.changelog-1.1.xml"/>
   <include  file="changelog/db.changelog-1.2.xml"/>
+  <include  file="changelog/db.changelog-1.3.xml"/>
 </databaseChangeLog>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-pay-enrichment",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "FFC Payment enrichment service",
   "homepage": "https://github.com/DEFRA/ffc-pay-enrichment",
   "main": "app/index.js",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SFI-1425

Standard to Scheme code mapping table contains only dummy data for SFI alpha.  Removing so only clean data is persisted now codes are confirmed.